### PR TITLE
T6DDK Add prop to listen onClick events outside bottom sheet

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-raw-bottom-sheet",
-  "version": "2.2.0",
+  "version": "2.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-raw-bottom-sheet",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-raw-bottom-sheet",
-  "version": "2.2.0-workast",
+  "version": "2.3.0-workast",
   "description": "Add Your Own Component To Bottom Sheet Whatever You Want (Android & iOS)",
   "main": "index.js",
   "typings": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-raw-bottom-sheet",
-  "version": "2.2.0-workast",
+  "version": "2.2.0",
   "description": "Add Your Own Component To Bottom Sheet Whatever You Want (Android & iOS)",
   "main": "index.js",
   "typings": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-raw-bottom-sheet",
-  "version": "2.2.0",
+  "version": "2.2.0-workast",
   "description": "Add Your Own Component To Bottom Sheet Whatever You Want (Android & iOS)",
   "main": "index.js",
   "typings": "index.d.ts",

--- a/src/index.js
+++ b/src/index.js
@@ -92,6 +92,7 @@ class RBSheet extends Component {
       animationType,
       closeOnDragDown,
       closeOnPressMask,
+      onCloseOnPressMask,
       closeOnPressBack,
       children,
       customStyles,
@@ -109,7 +110,10 @@ class RBSheet extends Component {
         visible={modalVisible}
         supportedOrientations={SUPPORTED_ORIENTATIONS}
         onRequestClose={() => {
-          if (closeOnPressBack) this.setModalVisible(false);
+          if (closeOnPressBack) {
+            this.setModalVisible(false);
+            this.close();
+          }
         }}
       >
         <KeyboardAvoidingView
@@ -120,7 +124,7 @@ class RBSheet extends Component {
           <TouchableOpacity
             style={styles.mask}
             activeOpacity={1}
-            onPress={() => (closeOnPressMask ? this.close() : null)}
+            onPress={() => (closeOnPressMask ? this.close() : onCloseOnPressMask())}
           />
           <Animated.View
             {...this.panResponder.panHandlers}
@@ -152,7 +156,8 @@ RBSheet.propTypes = {
   customStyles: PropTypes.objectOf(PropTypes.object),
   onClose: PropTypes.func,
   onOpen: PropTypes.func,
-  children: PropTypes.node
+  children: PropTypes.node,
+  onCloseOnPressMask: PropTypes.func
 };
 
 RBSheet.defaultProps = {
@@ -168,6 +173,7 @@ RBSheet.defaultProps = {
   customStyles: {},
   onClose: null,
   onOpen: null,
+  onCloseOnPressMask: null,
   children: <View />
 };
 

--- a/src/index.js
+++ b/src/index.js
@@ -124,7 +124,14 @@ class RBSheet extends Component {
           <TouchableOpacity
             style={styles.mask}
             activeOpacity={1}
-            onPress={() => (closeOnPressMask ? this.close() : onCloseOnPressMask())}
+            onPress={() => 
+              {
+                if (typeof onCloseOnPressMask === "function") onCloseOnPressMask();
+                if (closeOnPressMask) {
+                  this.close();
+                }
+              }
+            }
           />
           <Animated.View
             {...this.panResponder.panHandlers}


### PR DESCRIPTION
**T6DDK Update react-native-raw-bottom-sheet library in order to listen onClick events outside bottom sheet**

Demo: https://imgur.com/a/wVt5e08

This change is an improvement in react-native-raw-bottom-sheet library in order to listen when the user makes click outside the bottom sheet. This improvement allows us to make some custom action from the app side when the user makes this action. 

**Implementation**
I added a new prop to listen when the user makes click outside, and return a callback function so in the mobile app can fire a custom action.

