### PR TITLE
TDEK1 Update react-native-raw-bottom-sheet library: Add  onCloseOnPressMask onRequestClose method

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -110,10 +110,10 @@ class RBSheet extends Component {
         visible={modalVisible}
         supportedOrientations={SUPPORTED_ORIENTATIONS}
         onRequestClose={() => {
-          if (closeOnPressBack) {
-            this.setModalVisible(false);
+          if (closeOnPressMask) {
             this.close();
           }
+          if (typeof onCloseOnPressMask === "function") onCloseOnPressMask();
         }}
       >
         <KeyboardAvoidingView


### PR DESCRIPTION
[x] **TDEK1 Update react-native-raw-bottom-sheet library: Add  onCloseOnPressMask onRequestClose method**

Android: https://imgur.com/a/BRrBAJ2
iOS: https://imgur.com/a/idCcOoV

This PR is related to this feature in Workast Mobile App [PR](https://bitbucket.org/zlapps/mobile-app/pull-requests/128/t1fgm-back-main-create-task-view-list) --  
This change deals with detect when the user use back hardware button from the modal and call  onCloseOnPressMask method who it's in charge to apply the correct logic:
- If the user is in a sublist/list view, it should go back
- If the user is in the main create task view and the summary text has some words, it should show the warning message
- if the user is in the main create task view and the summary text is empty, it should show the modal

Implementation
React-native-raw-bottom-sheet library is using modal component. Warning for modal users: If your app shows an opened Modal, BackHandler will not publish any events so we need to use `onRequestClose` method from modal react-native component to handle this scenario.